### PR TITLE
Regeln zum Beitragen zur Webseite festgelegt.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,13 @@
+Regeln für dieses Repository:
+
+- Jeder, der im Makerklub ist, hat das Recht, beizutragen.
+- Beiträge werden über Pull-Requests eingereicht.
+- Pull-Requests haben diese Form:
+
+        Problem: ...
+        
+        Lösung: ...
+        
+- Eine andere Person merged die Pull-Request.
+- Erst nach 1-2 Tagen Inaktivität auf der Pull-Request darf man sie selbst mergen.
+- Für Weiteres siehe [Collective Code Construction Contract](https://rfc.zeromq.org/spec:42/C4).


### PR DESCRIPTION
Problem: Ich möchte, dass alle an der Webseite mitwirken, nicht nur ich. Das soll schnell erkennbar sein.

Lösung: Es gibt den C4-Vertrag, der Kollaboration in Open-Source-Projekten regelt. Damit man sein Recht beizutragen schnell erkennt, wird hier nochmal kurz umrissen, was drin steht.
