### PR TITLE
Leichterer Einstieg ins Editieren der Seite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,8 @@
 
 Das ist die Webseite auf [HPIMakerKlub.github.io](http://HPIMakerKlub.github.io).
 
-Zum Entwickeln sollte [Jekyll](http://jekyllrb.com/) installiert sein.
+Um die Seite zu verändern kannst du
+
+- Die Seite editieren und eine Pull-Request erstellen. In ihr wird angezeigt, ob die Seite funktioniert.
+- [Jekyll](http://jekyllrb.com/) lokal installieren.
+- Dieses Repository forken, den `gh-pages`-branch erstellen und auf `https://<MyUserName>.github.io/HPIMakerklub.github.io` die geforkte Version ansehen.


### PR DESCRIPTION
Problem: Jekyll zu installieren schreckt vielleicht ab, an der Seite mitzuwirken.

Lösung: Zwei andere Möglichkeiten, die Seite mit weniger Aufwand zu editieren, beschrieben.
